### PR TITLE
feat: implement compliance feature flags for FHIR, ICD-10, ISO 27001,…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+# Restore dependencies
+dotnet restore
+
+# Run the API (dev, http://localhost:5189)
+dotnet run
+
+# Build without running
+dotnet build
+
+# Apply EF Core migrations (dev only — prod auto-migrates on startup)
+dotnet ef database update
+
+# Add a new EF Core migration
+dotnet ef migrations add <MigrationName>
+
+# Docker build
+docker build -t sanalink-api .
+```
+
+There are no automated tests in this project.
+
+## Architecture
+
+Single-project ASP.NET Core 9 Web API (`Sanalink.API.csproj`). All code lives in the root; there is no layered solution with multiple .csproj files.
+
+**Request flow:**
+```
+HTTP Request
+  → AuditLoggingMiddleware (buffers req/res bodies, persists AuditLog after every request)
+  → Controller (thin — delegates to Service)
+  → Service (business logic, EF Core queries)
+  → AppDbContext (PostgreSQL via Npgsql)
+```
+
+### Key architectural decisions
+
+**Multi-database setup:** The project references both `Npgsql.EntityFrameworkCore.PostgreSQL` and `Microsoft.EntityFrameworkCore.Sqlite`. Production and development both use PostgreSQL (`DefaultConnection` in `appsettings.json`). SQLite is a leftover/fallback and is not used in the active config.
+
+**Dual-environment config:** `appsettings.Development.json` holds dev credentials. Production connection string and JWT key must be supplied via environment variables or a secrets manager — `appsettings.Production.json` only overrides Serilog levels. EF migrations run automatically on startup in Production only; in Development, run `dotnet ef database update` manually.
+
+**DateTime handling:** `AppDbContext.OnModelCreating` installs a global EF value converter that stores all `DateTime` properties as UTC and reads them back as `DateTimeKind.Utc`. Always use `DateTime.UtcNow` — never `DateTime.Now`.
+
+**Audit logging:** `AuditLoggingMiddleware` intercepts every request, captures request/response bodies (skipping `/auth/login` and `/auth/register-staff`), and writes an `AuditLog` row. `SensitiveDataMasker` scrubs known sensitive JSON keys (`password`, `token`, etc.) before storage.
+
+**JWT claims:** The token includes `sub` (userId), `email`, `firstName`, `lastName`, `role` (both as `ClaimTypes.Role` and a custom `"role"` claim), and `facilityId`. Controllers read `facilityId` via `User.FindFirstValue("facilityId")` to scope queries to the user's facility.
+
+**Facility scoping:** Most staff endpoints filter results by the caller's `facilityId` claim when it is present. Admins without a facility see all records.
+
+**Encounter status workflow:** Encounters follow a strict linear state machine enforced in `EncounterService.UpdateStatusAsync`: `Open → InProgress → Closed`. Any other transition is rejected. Encounter numbers are auto-generated as `ENC-{yyyyMMdd}-{sequence:D3}`.
+
+**Service pattern:** Each domain (Encounter, Prescription, LabOrder, etc.) has an interface (`IXService`) and implementation registered as `AddScoped`. Controllers never query `AppDbContext` directly except in `AuthController`, which uses `UserManager<ApplicationUser>` and `_db` for Identity operations.
+
+### Roles
+
+Seeded at startup by `RoleSeeder`: `Admin`, `Doctor`, `Nurse`, `Accueil`, `Caisse`, `DAF`, `LabTech`, `Pharmacist`.
+
+Default admin: `admin@sanalink.com` / `Admin@123456` (change in production).
+
+### Logging
+
+Serilog writes to console, rolling daily files (`logs/sanalink-.log`, 14-day retention), and optionally to BetterStack when `BetterStack:SourceToken` is configured.
+
+### CORS
+
+Development allows `localhost` origins; production allows `*.vercel.app` origins (`AllowVercel` policy).
+
+### All endpoints are prefixed `/api/v1`
+
+Route template: `[Route("api/v1/[controller]")]` on each controller.

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -1,11 +1,15 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement;
 using Microsoft.IdentityModel.Tokens;
 using Sanalink.API.Data;
 using Sanalink.API.DTOs;
+using Sanalink.API.Infrastructure;
 using Sanalink.API.Models;
+using Sanalink.API.Services;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text;
@@ -20,17 +24,23 @@ public class AuthController : ControllerBase
     private readonly SignInManager<ApplicationUser> _signInManager;
     private readonly IConfiguration _config;
     private readonly AppDbContext _db;
+    private readonly IFeatureManager _features;
+    private readonly ITokenRevocationService _tokenRevocation;
 
     public AuthController(
         UserManager<ApplicationUser> userManager,
         SignInManager<ApplicationUser> signInManager,
         IConfiguration config,
-        AppDbContext db)
+        AppDbContext db,
+        IFeatureManager features,
+        ITokenRevocationService tokenRevocation)
     {
-        _userManager = userManager;
-        _signInManager = signInManager;
-        _config = config;
-        _db = db;
+        _userManager     = userManager;
+        _signInManager   = signInManager;
+        _config          = config;
+        _db              = db;
+        _features        = features;
+        _tokenRevocation = tokenRevocation;
     }
 
     [HttpPost("register-staff")]
@@ -47,15 +57,15 @@ public class AuthController : ControllerBase
 
         var user = new ApplicationUser
         {
-            UserName = dto.Email,
-            Email = dto.Email,
-            FirstName = dto.FirstName,
-            LastName = dto.LastName,
-            Role = dto.Role,
-            Department = dto.Department,
-            FacilityId = dto.FacilityId,
+            UserName       = dto.Email,
+            Email          = dto.Email,
+            FirstName      = dto.FirstName,
+            LastName       = dto.LastName,
+            Role           = dto.Role,
+            Department     = dto.Department,
+            FacilityId     = dto.FacilityId,
             EmailConfirmed = true,
-            IsActive = true
+            IsActive       = true
         };
 
         var result = await _userManager.CreateAsync(user, dto.Password);
@@ -63,7 +73,6 @@ public class AuthController : ControllerBase
             return BadRequest(result.Errors);
 
         await _userManager.AddToRoleAsync(user, dto.Role);
-
         return Ok("Registration successful");
     }
 
@@ -72,19 +81,18 @@ public class AuthController : ControllerBase
     public async Task<IActionResult> GetAllStaff()
     {
         var users = await _userManager.Users
-            .OrderBy(u => u.LastName)
-            .ThenBy(u => u.FirstName)
+            .OrderBy(u => u.LastName).ThenBy(u => u.FirstName)
             .Select(u => new StaffReadDto
             {
-                Id = u.Id,
-                Email = u.Email ?? "",
-                FirstName = u.FirstName ?? "",
-                LastName = u.LastName ?? "",
-                Role = u.Role,
+                Id         = u.Id,
+                Email      = u.Email ?? "",
+                FirstName  = u.FirstName ?? "",
+                LastName   = u.LastName ?? "",
+                Role       = u.Role,
                 Department = u.Department,
                 FacilityId = u.FacilityId,
-                IsActive = u.IsActive,
-                CreatedAt = u.CreateAt
+                IsActive   = u.IsActive,
+                CreatedAt  = u.CreateAt
             })
             .ToListAsync();
 
@@ -92,18 +100,50 @@ public class AuthController : ControllerBase
     }
 
     [HttpPost("login")]
+    [EnableRateLimiting(FeatureFlags.RatePolicy_AuthLogin)]
     public async Task<IActionResult> Login(LoginDto dto)
     {
+        var lockoutEnabled = await _features.IsEnabledAsync(FeatureFlags.ISO27001_AccountLockout);
+
         var user = await _userManager.FindByNameAsync(dto.Email);
         if (user == null || !user.IsActive)
             return Unauthorized("Invalid credentials");
 
-        var result = await _signInManager.CheckPasswordSignInAsync(user, dto.Password, false);
+        var result = await _signInManager.CheckPasswordSignInAsync(user, dto.Password, lockoutOnFailure: lockoutEnabled);
+
+        if (result.IsLockedOut)
+            return StatusCode(429, new { error = "Account is temporarily locked after too many failed attempts. Try again in 15 minutes." });
+
         if (!result.Succeeded)
             return Unauthorized("Invalid credentials");
 
         var token = GenerateJwtToken(user);
         return Ok(new { token });
+    }
+
+    /// <summary>
+    /// Revokes the caller's current token so it cannot be reused.
+    /// Effective only when ISO27001_TokenRevocation is enabled.
+    /// </summary>
+    [HttpPost("logout")]
+    [Authorize]
+    public async Task<IActionResult> Logout()
+    {
+        if (await _features.IsEnabledAsync(FeatureFlags.ISO27001_TokenRevocation))
+        {
+            var jti    = User.FindFirstValue(JwtRegisteredClaimNames.Jti);
+            var userId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var expStr = User.FindFirstValue(JwtRegisteredClaimNames.Exp);
+
+            DateTime expiresAt = DateTime.UtcNow.AddHours(4);
+            if (long.TryParse(expStr, out long expUnix))
+                expiresAt = DateTimeOffset.FromUnixTimeSeconds(expUnix).UtcDateTime;
+
+            if (!string.IsNullOrEmpty(jti))
+                await _tokenRevocation.RevokeAsync(jti, userId!, expiresAt);
+        }
+
+        return Ok(new { message = "Logged out successfully." });
     }
 
     [HttpGet("doctors")]
@@ -113,12 +153,9 @@ public class AuthController : ControllerBase
         var facilityIdClaim = User.FindFirstValue("facilityId");
         int.TryParse(facilityIdClaim, out int facilityId);
 
-        var query = _userManager.Users
+        var doctors = await _userManager.Users
             .Where(u => u.Role == "Doctor" && u.IsActive)
-            .OrderBy(u => u.LastName)
-            .ThenBy(u => u.FirstName);
-
-        var doctors = await query
+            .OrderBy(u => u.LastName).ThenBy(u => u.FirstName)
             .Select(u => new { u.Id, u.FirstName, u.LastName, u.Department, u.FacilityId })
             .ToListAsync();
 
@@ -143,42 +180,34 @@ public class AuthController : ControllerBase
         int.TryParse(facilityIdClaim, out int facilityId);
 
         var doctors = await _userManager.GetUsersInRoleAsync("Doctor");
-        var nurses = await _userManager.GetUsersInRoleAsync("Nurse");
+        var nurses  = await _userManager.GetUsersInRoleAsync("Nurse");
 
-        var doctorCount = facilityId > 0
-            ? doctors.Count(d => d.FacilityId == facilityId)
-            : doctors.Count;
+        var doctorCount = facilityId > 0 ? doctors.Count(d => d.FacilityId == facilityId) : doctors.Count;
+        var nurseCount  = facilityId > 0 ? nurses.Count(n => n.FacilityId == facilityId)  : nurses.Count;
 
-        var nurseCount = facilityId > 0
-            ? nurses.Count(n => n.FacilityId == facilityId)
-            : nurses.Count;
-
-        return Ok(new
-        {
-            doctors = doctorCount,
-            nurseCount = nurseCount
-        });
+        return Ok(new { doctors = doctorCount, nurseCount });
     }
 
     private string GenerateJwtToken(ApplicationUser user)
     {
         var claims = new List<Claim>
         {
-            new Claim(JwtRegisteredClaimNames.Sub, user.Id),
+            new Claim(JwtRegisteredClaimNames.Sub,   user.Id),
+            new Claim(JwtRegisteredClaimNames.Jti,   Guid.NewGuid().ToString()),  // required for token revocation
             new Claim(JwtRegisteredClaimNames.Email, user.Email ?? ""),
-            new Claim("firstName", user.FirstName ?? ""),
-            new Claim("lastName", user.LastName ?? ""),
-            new Claim(ClaimTypes.Role, user.Role ?? ""),
-            new Claim("role", user.Role ?? ""),
-            new Claim("facilityId", user.FacilityId?.ToString() ?? "")
+            new Claim("firstName",          user.FirstName ?? ""),
+            new Claim("lastName",           user.LastName  ?? ""),
+            new Claim(ClaimTypes.Role,      user.Role ?? ""),
+            new Claim("role",               user.Role ?? ""),
+            new Claim("facilityId",         user.FacilityId?.ToString() ?? "")
         };
 
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!));
+        var key   = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_config["Jwt:Key"]!));
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
         var token = new JwtSecurityToken(
-            claims: claims,
-            expires: DateTime.UtcNow.AddHours(4),
+            claims:            claims,
+            expires:           DateTime.UtcNow.AddHours(4),
             signingCredentials: creds
         );
 

--- a/Controllers/Dhis2Controller.cs
+++ b/Controllers/Dhis2Controller.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using Sanalink.API.Infrastructure;
+using Sanalink.API.Services;
+
+namespace Sanalink.API.Controllers;
+
+[ApiController]
+[Route("api/v1/dhis2")]
+[Authorize(Roles = "Admin,DAF")]
+[FeatureGate(FeatureFlags.DHIS2)]
+public class Dhis2Controller : ControllerBase
+{
+    private readonly IDhis2ExportService _exportService;
+
+    public Dhis2Controller(IDhis2ExportService exportService) => _exportService = exportService;
+
+    /// <summary>
+    /// Manually trigger a DHIS2 export for a given period.
+    /// Period format: yyyyMM (e.g. "202601" for January 2026).
+    /// </summary>
+    [HttpPost("export")]
+    public async Task<IActionResult> Export([FromQuery] string period)
+    {
+        if (string.IsNullOrWhiteSpace(period) || period.Length != 6)
+            return BadRequest("Period must be in yyyyMM format, e.g. '202601'.");
+
+        var result = await _exportService.ExportAsync(period, HttpContext.RequestAborted);
+        return result.Success ? Ok(result) : StatusCode(502, result);
+    }
+}

--- a/Controllers/Fhir/FhirCapabilityController.cs
+++ b/Controllers/Fhir/FhirCapabilityController.cs
@@ -1,0 +1,61 @@
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.FeatureManagement.Mvc;
+using Sanalink.API.Infrastructure;
+
+namespace Sanalink.API.Controllers.Fhir;
+
+/// <summary>
+/// GET /fhir/r4/metadata — FHIR CapabilityStatement describing this server's conformance.
+/// Gated by the FHIR feature flag.
+/// </summary>
+[ApiController]
+[Route("fhir/r4")]
+[FeatureGate(FeatureFlags.FHIR)]
+public class FhirCapabilityController : ControllerBase
+{
+    private static readonly FhirJsonSerializer Serializer = new(new SerializerSettings { Pretty = false });
+
+    [HttpGet("metadata")]
+    public ContentResult GetCapabilityStatement()
+    {
+        var cs = new CapabilityStatement
+        {
+            Status      = PublicationStatus.Active,
+            Date        = DateTime.UtcNow.ToString("yyyy-MM-dd"),
+            Kind        = CapabilityStatementKind.Instance,
+            FhirVersion = FHIRVersion.N4_0_1,
+            Format      = new[] { "application/fhir+json" },
+            Software    = new CapabilityStatement.SoftwareComponent { Name = "Sanalink API" },
+            Rest        = new List<CapabilityStatement.RestComponent>
+            {
+                new CapabilityStatement.RestComponent
+                {
+                    Mode = CapabilityStatement.RestfulCapabilityMode.Server,
+                    Resource = new List<CapabilityStatement.ResourceComponent>
+                    {
+                        FhirResource("Patient",
+                            CapabilityStatement.TypeRestfulInteraction.Read,
+                            CapabilityStatement.TypeRestfulInteraction.SearchType),
+                        FhirResource("Encounter",
+                            CapabilityStatement.TypeRestfulInteraction.Read,
+                            CapabilityStatement.TypeRestfulInteraction.SearchType),
+                    }
+                }
+            }
+        };
+
+        return Content(Serializer.SerializeToString(cs), "application/fhir+json");
+    }
+
+    private static CapabilityStatement.ResourceComponent FhirResource(
+        string typeName, params CapabilityStatement.TypeRestfulInteraction[] interactions) =>
+        new CapabilityStatement.ResourceComponent
+        {
+            TypeElement = new Code(typeName),
+            Interaction = interactions
+                .Select(i => new CapabilityStatement.ResourceInteractionComponent { Code = i })
+                .ToList()
+        };
+}

--- a/Controllers/Fhir/FhirEncounterController.cs
+++ b/Controllers/Fhir/FhirEncounterController.cs
@@ -1,0 +1,111 @@
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement.Mvc;
+using Sanalink.API.Data;
+using Sanalink.API.Infrastructure;
+using Sanalink.API.Services.Fhir;
+
+namespace Sanalink.API.Controllers.Fhir;
+
+/// <summary>
+/// FHIR R4 Encounter endpoints.
+/// Route: /fhir/r4/Encounter
+/// Gated by the FHIR feature flag; returns application/fhir+json.
+/// </summary>
+[ApiController]
+[Route("fhir/r4/Encounter")]
+[Authorize]
+[FeatureGate(FeatureFlags.FHIR)]
+public class FhirEncounterController : ControllerBase
+{
+    private static readonly FhirJsonSerializer Serializer = new(new SerializerSettings { Pretty = false });
+
+    private readonly AppDbContext _db;
+    private readonly FhirMappingService _mapper;
+
+    public FhirEncounterController(AppDbContext db, FhirMappingService mapper)
+    {
+        _db = db;
+        _mapper = mapper;
+    }
+
+    /// <summary>GET /fhir/r4/Encounter/{id}</summary>
+    [HttpGet("{id:int}")]
+    [Authorize(Roles = "Doctor,Nurse,Admin")]
+    public async Task<ContentResult> GetById(int id)
+    {
+        var encounter = await _db.Encounters
+            .Include(e => e.Patient)
+            .Include(e => e.Doctor)
+            .Include(e => e.Nurse)
+            .Include(e => e.Diagnoses)
+            .FirstOrDefaultAsync(e => e.Id == id);
+
+        if (encounter is null)
+            return FhirNotFound($"Encounter/{id}");
+
+        return FhirJson(_mapper.ToFhirEncounter(encounter));
+    }
+
+    /// <summary>GET /fhir/r4/Encounter?subject=Patient/{patientId}&status=</summary>
+    [HttpGet]
+    [Authorize(Roles = "Doctor,Nurse,Admin")]
+    public async Task<ContentResult> Search(
+        [FromQuery] string? subject,
+        [FromQuery] string? status)
+    {
+        var query = _db.Encounters
+            .Include(e => e.Patient)
+            .Include(e => e.Doctor)
+            .Include(e => e.Diagnoses)
+            .AsQueryable();
+
+        // subject format: "Patient/42"
+        if (!string.IsNullOrWhiteSpace(subject))
+        {
+            var parts = subject.Split('/');
+            if (parts.Length == 2 && int.TryParse(parts[1], out int patientId))
+                query = query.Where(e => e.PatientId == patientId);
+        }
+
+        if (!string.IsNullOrWhiteSpace(status))
+            query = query.Where(e => e.Status == status);
+
+        var encounters = await query.Take(50).ToListAsync();
+
+        var bundle = new Bundle
+        {
+            Type  = Bundle.BundleType.Searchset,
+            Total = encounters.Count,
+            Entry = encounters
+                .Select(e => new Bundle.EntryComponent { Resource = _mapper.ToFhirEncounter(e) })
+                .ToList()
+        };
+
+        return FhirJson(bundle);
+    }
+
+    private ContentResult FhirJson(Resource resource)
+        => Content(Serializer.SerializeToString(resource), "application/fhir+json");
+
+    private ContentResult FhirNotFound(string reference)
+    {
+        Response.StatusCode = StatusCodes.Status404NotFound;
+        var outcome = new OperationOutcome
+        {
+            Issue = new List<OperationOutcome.IssueComponent>
+            {
+                new OperationOutcome.IssueComponent
+                {
+                    Severity    = OperationOutcome.IssueSeverity.Error,
+                    Code        = OperationOutcome.IssueType.NotFound,
+                    Diagnostics = $"{reference} not found"
+                }
+            }
+        };
+        return Content(Serializer.SerializeToString(outcome), "application/fhir+json");
+    }
+}

--- a/Controllers/Fhir/FhirPatientController.cs
+++ b/Controllers/Fhir/FhirPatientController.cs
@@ -1,0 +1,94 @@
+using Hl7.Fhir.Model;
+using Hl7.Fhir.Serialization;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement.Mvc;
+using Sanalink.API.Data;
+using Sanalink.API.Infrastructure;
+using Sanalink.API.Services.Fhir;
+
+namespace Sanalink.API.Controllers.Fhir;
+
+/// <summary>
+/// FHIR R4 Patient endpoints.
+/// Route: /fhir/r4/Patient
+/// Gated by the FHIR feature flag; returns application/fhir+json.
+/// </summary>
+[ApiController]
+[Route("fhir/r4/Patient")]
+[Authorize]
+[FeatureGate(FeatureFlags.FHIR)]
+public class FhirPatientController : ControllerBase
+{
+    private static readonly FhirJsonSerializer Serializer = new(new SerializerSettings { Pretty = false });
+
+    private readonly AppDbContext _db;
+    private readonly FhirMappingService _mapper;
+
+    public FhirPatientController(AppDbContext db, FhirMappingService mapper)
+    {
+        _db = db;
+        _mapper = mapper;
+    }
+
+    /// <summary>GET /fhir/r4/Patient/{id}</summary>
+    [HttpGet("{id:int}")]
+    [Authorize(Roles = "Doctor,Nurse,Admin,Accueil")]
+    public async Task<ContentResult> GetById(int id)
+    {
+        var patient = await _db.Patients.FindAsync(id);
+        if (patient is null)
+            return FhirNotFound($"Patient/{id}");
+
+        return FhirJson(_mapper.ToFhirPatient(patient));
+    }
+
+    /// <summary>GET /fhir/r4/Patient?family=&given=</summary>
+    [HttpGet]
+    [Authorize(Roles = "Doctor,Nurse,Admin,Accueil")]
+    public async Task<ContentResult> Search([FromQuery] string? family, [FromQuery] string? given)
+    {
+        var query = _db.Patients.AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(family))
+            query = query.Where(p => p.LastName.Contains(family));
+
+        if (!string.IsNullOrWhiteSpace(given))
+            query = query.Where(p => p.FirstName.Contains(given));
+
+        var patients = await query.Take(50).ToListAsync();
+
+        var bundle = new Bundle
+        {
+            Type  = Bundle.BundleType.Searchset,
+            Total = patients.Count,
+            Entry = patients
+                .Select(p => new Bundle.EntryComponent { Resource = _mapper.ToFhirPatient(p) })
+                .ToList()
+        };
+
+        return FhirJson(bundle);
+    }
+
+    private ContentResult FhirJson(Resource resource)
+        => Content(Serializer.SerializeToString(resource), "application/fhir+json");
+
+    private ContentResult FhirNotFound(string reference)
+    {
+        Response.StatusCode = StatusCodes.Status404NotFound;
+        var outcome = new OperationOutcome
+        {
+            Issue = new List<OperationOutcome.IssueComponent>
+            {
+                new OperationOutcome.IssueComponent
+                {
+                    Severity    = OperationOutcome.IssueSeverity.Error,
+                    Code        = OperationOutcome.IssueType.NotFound,
+                    Diagnostics = $"{reference} not found"
+                }
+            }
+        };
+        return Content(Serializer.SerializeToString(outcome), "application/fhir+json");
+    }
+}

--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -19,9 +19,26 @@ namespace Sanalink.API.Data
         public DbSet<LabOrder> LabOrders { get; set; }
         public DbSet<PharmacyDispense> PharmacyDispenses { get; set; }
 
+        // Compliance tables — always migrated, usage controlled by feature flags
+        public DbSet<EncounterDiagnosis> EncounterDiagnoses { get; set; }
+        public DbSet<TokenBlacklist> TokenBlacklists { get; set; }
+        public DbSet<Dhis2Mapping> Dhis2Mappings { get; set; }
+
         protected override void OnModelCreating(ModelBuilder builder)
         {
             base.OnModelCreating(builder);
+
+            // EncounterDiagnosis -> Encounter
+            builder.Entity<EncounterDiagnosis>()
+                .HasOne(d => d.Encounter)
+                .WithMany(e => e.Diagnoses)
+                .HasForeignKey(d => d.EncounterId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            // TokenBlacklist index on Jti for fast revocation lookups
+            builder.Entity<TokenBlacklist>()
+                .HasIndex(t => t.Jti)
+                .IsUnique();
 
             // AuditLog -> ApplicationUser (optional FK)
             builder.Entity<AuditLog>()

--- a/Dtos/EncounterCreateDto.cs
+++ b/Dtos/EncounterCreateDto.cs
@@ -1,9 +1,11 @@
-namespace Sanalink.API.DTOs
+namespace Sanalink.API.DTOs;
+
+public class EncounterCreateDto
 {
-    public class EncounterCreateDto
-    {
-        public int PatientId { get; set; }
-        public string ChiefComplaint { get; set; } = default!;
-        public string? Vitals { get; set; }
-    }
+    public int PatientId { get; set; }
+    public string ChiefComplaint { get; set; } = default!;
+    public string? Vitals { get; set; }
+
+    /// <summary>ICD-10 coded diagnoses. Only persisted when the ICD10 feature flag is enabled.</summary>
+    public List<EncounterDiagnosisCreateDto>? Diagnoses { get; set; }
 }

--- a/Dtos/EncounterDiagnosisDto.cs
+++ b/Dtos/EncounterDiagnosisDto.cs
@@ -1,0 +1,29 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Sanalink.API.DTOs;
+
+public class EncounterDiagnosisCreateDto
+{
+    [Required]
+    [MaxLength(10)]
+    public string ICD10Code { get; set; } = default!;
+
+    [Required]
+    [MaxLength(500)]
+    public string ICD10Description { get; set; } = default!;
+
+    /// <summary>Primary | Secondary | Comorbidity</summary>
+    [MaxLength(20)]
+    public string DiagnosisType { get; set; } = "Primary";
+
+    public int Rank { get; set; } = 1;
+}
+
+public class EncounterDiagnosisReadDto
+{
+    public int Id { get; set; }
+    public string ICD10Code { get; set; } = default!;
+    public string ICD10Description { get; set; } = default!;
+    public string DiagnosisType { get; set; } = default!;
+    public int Rank { get; set; }
+}

--- a/Dtos/EncounterReadDto.cs
+++ b/Dtos/EncounterReadDto.cs
@@ -1,20 +1,25 @@
-namespace Sanalink.API.DTOs
+namespace Sanalink.API.DTOs;
+
+public class EncounterReadDto
 {
-    public class EncounterReadDto
-    {
-        public int Id { get; set; }
-        public string EncounterNumber { get; set; } = default!;
-        public int PatientId { get; set; }
-        public string PatientName { get; set; } = default!;
-        public string DoctorName { get; set; } = default!;
-        public string? NurseName { get; set; }
-        public string Status { get; set; } = default!;
-        public string ChiefComplaint { get; set; } = default!;
-        public string? Vitals { get; set; }
-        public string? Diagnosis { get; set; }
-        public string? ClinicalNotes { get; set; }
-        public DateTime CreatedAt { get; set; }
-        public DateTime? UpdatedAt { get; set; }
-        public DateTime? ClosedAt { get; set; }
-    }
+    public int Id { get; set; }
+    public string EncounterNumber { get; set; } = default!;
+    public int PatientId { get; set; }
+    public string PatientName { get; set; } = default!;
+    public string DoctorName { get; set; } = default!;
+    public string? NurseName { get; set; }
+    public string Status { get; set; } = default!;
+    public string ChiefComplaint { get; set; } = default!;
+    public string? Vitals { get; set; }
+
+    /// <summary>Free-text diagnosis (legacy / ICD10 flag off).</summary>
+    public string? Diagnosis { get; set; }
+
+    /// <summary>Structured ICD-10 diagnoses (populated when ICD10 flag is on).</summary>
+    public List<EncounterDiagnosisReadDto>? Diagnoses { get; set; }
+
+    public string? ClinicalNotes { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime? UpdatedAt { get; set; }
+    public DateTime? ClosedAt { get; set; }
 }

--- a/Dtos/EncounterUpdateDto.cs
+++ b/Dtos/EncounterUpdateDto.cs
@@ -1,11 +1,13 @@
-namespace Sanalink.API.DTOs
+namespace Sanalink.API.DTOs;
+
+public class EncounterUpdateDto
 {
-    public class EncounterUpdateDto
-    {
-        public string? ChiefComplaint { get; set; }
-        public string? Vitals { get; set; }
-        public string? Diagnosis { get; set; }
-        public string? ClinicalNotes { get; set; }
-        public string? NurseId { get; set; }
-    }
+    public string? ChiefComplaint { get; set; }
+    public string? Vitals { get; set; }
+    public string? Diagnosis { get; set; }
+    public string? ClinicalNotes { get; set; }
+    public string? NurseId { get; set; }
+
+    /// <summary>Replaces all ICD-10 diagnoses on the encounter when ICD10 flag is enabled.</summary>
+    public List<EncounterDiagnosisCreateDto>? Diagnoses { get; set; }
 }

--- a/Infrastructure/FeatureFlags.cs
+++ b/Infrastructure/FeatureFlags.cs
@@ -1,0 +1,20 @@
+namespace Sanalink.API.Infrastructure;
+
+public static class FeatureFlags
+{
+    // ISO/IEC 27001 controls
+    public const string ISO27001_Https           = "ISO27001_Https";
+    public const string ISO27001_SwaggerGate     = "ISO27001_SwaggerGate";
+    public const string ISO27001_RateLimiting    = "ISO27001_RateLimiting";
+    public const string ISO27001_AccountLockout  = "ISO27001_AccountLockout";
+    public const string ISO27001_TokenRevocation = "ISO27001_TokenRevocation";
+    public const string ISO27001_DataRetention   = "ISO27001_DataRetention";
+
+    // Standards
+    public const string ICD10 = "ICD10";
+    public const string FHIR  = "FHIR";
+    public const string DHIS2 = "DHIS2";
+
+    // Rate limiter policy name (used by both Program.cs and AuthController attribute)
+    public const string RatePolicy_AuthLogin = "rate-auth-login";
+}

--- a/Middleware/TokenRevocationMiddleware.cs
+++ b/Middleware/TokenRevocationMiddleware.cs
@@ -1,0 +1,38 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Sanalink.API.Services;
+
+namespace Sanalink.API.Middleware;
+
+/// <summary>
+/// Rejects requests whose JWT has been revoked via POST /api/v1/auth/logout.
+/// Only active when the ISO27001_TokenRevocation feature flag is on.
+/// </summary>
+public class TokenRevocationMiddleware
+{
+    private readonly RequestDelegate _next;
+
+    public TokenRevocationMiddleware(RequestDelegate next) => _next = next;
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (context.User.Identity?.IsAuthenticated == true)
+        {
+            var jti = context.User.FindFirstValue(JwtRegisteredClaimNames.Jti);
+            if (!string.IsNullOrEmpty(jti))
+            {
+                var revocationSvc = context.RequestServices
+                    .GetRequiredService<ITokenRevocationService>();
+
+                if (await revocationSvc.IsRevokedAsync(jti))
+                {
+                    context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+                    await context.Response.WriteAsJsonAsync(new { error = "Token has been revoked. Please log in again." });
+                    return;
+                }
+            }
+        }
+
+        await _next(context);
+    }
+}

--- a/Migrations/20260603211602_AddComplianceTables.Designer.cs
+++ b/Migrations/20260603211602_AddComplianceTables.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Sanalink.API.Data;
@@ -11,9 +12,11 @@ using Sanalink.API.Data;
 namespace Sanalink.API.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260603211602_AddComplianceTables")]
+    partial class AddComplianceTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Migrations/20260603211602_AddComplianceTables.cs
+++ b/Migrations/20260603211602_AddComplianceTables.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Sanalink.API.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddComplianceTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Dhis2Mappings",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    MetricName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    DataElementUid = table.Column<string>(type: "character varying(11)", maxLength: 11, nullable: false),
+                    FacilityId = table.Column<int>(type: "integer", nullable: true),
+                    OrgUnitUid = table.Column<string>(type: "character varying(11)", maxLength: 11, nullable: true),
+                    PeriodType = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    IsActive = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Dhis2Mappings", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "EncounterDiagnoses",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    EncounterId = table.Column<int>(type: "integer", nullable: false),
+                    ICD10Code = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    ICD10Description = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    DiagnosisType = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    Rank = table.Column<int>(type: "integer", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_EncounterDiagnoses", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_EncounterDiagnoses_Encounters_EncounterId",
+                        column: x => x.EncounterId,
+                        principalTable: "Encounters",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TokenBlacklists",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Jti = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    UserId = table.Column<string>(type: "character varying(450)", maxLength: 450, nullable: true),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    RevokedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TokenBlacklists", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_EncounterDiagnoses_EncounterId",
+                table: "EncounterDiagnoses",
+                column: "EncounterId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TokenBlacklists_Jti",
+                table: "TokenBlacklists",
+                column: "Jti",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Dhis2Mappings");
+
+            migrationBuilder.DropTable(
+                name: "EncounterDiagnoses");
+
+            migrationBuilder.DropTable(
+                name: "TokenBlacklists");
+        }
+    }
+}

--- a/Models/Dhis2Mapping.cs
+++ b/Models/Dhis2Mapping.cs
@@ -1,0 +1,32 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Sanalink.API.Models;
+
+/// <summary>Maps a local aggregate metric to a DHIS2 Data Element and Organisation Unit.</summary>
+public class Dhis2Mapping
+{
+    public int Id { get; set; }
+
+    /// <summary>Internal metric name, e.g. "NewPatientRegistrations", "TotalAppointments".</summary>
+    [Required]
+    [MaxLength(100)]
+    public string MetricName { get; set; } = default!;
+
+    /// <summary>DHIS2 Data Element UID (11-char alphanumeric).</summary>
+    [Required]
+    [MaxLength(11)]
+    public string DataElementUid { get; set; } = default!;
+
+    /// <summary>Scope the metric to a specific facility (null = all facilities combined).</summary>
+    public int? FacilityId { get; set; }
+
+    /// <summary>DHIS2 Organisation Unit UID for the target facility.</summary>
+    [MaxLength(11)]
+    public string? OrgUnitUid { get; set; }
+
+    /// <summary>Daily | Weekly | Monthly</summary>
+    [MaxLength(10)]
+    public string PeriodType { get; set; } = "Monthly";
+
+    public bool IsActive { get; set; } = true;
+}

--- a/Models/Encounter.cs
+++ b/Models/Encounter.cs
@@ -49,5 +49,8 @@ namespace Sanalink.API.Models
         public DateTime? UpdatedAt { get; set; }
 
         public DateTime? ClosedAt { get; set; }
+
+        /// <summary>ICD-10 coded diagnoses — populated when ICD10 feature flag is on.</summary>
+        public ICollection<EncounterDiagnosis>? Diagnoses { get; set; }
     }
 }

--- a/Models/EncounterDiagnosis.cs
+++ b/Models/EncounterDiagnosis.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Sanalink.API.Models;
+
+public class EncounterDiagnosis
+{
+    public int Id { get; set; }
+
+    [Required]
+    public int EncounterId { get; set; }
+
+    [ForeignKey("EncounterId")]
+    public Encounter Encounter { get; set; } = default!;
+
+    /// <summary>ICD-10 / CIM-10 code, e.g. "J18.9"</summary>
+    [Required]
+    [MaxLength(10)]
+    public string ICD10Code { get; set; } = default!;
+
+    /// <summary>Human-readable label, e.g. "Pneumonie, sans précision"</summary>
+    [Required]
+    [MaxLength(500)]
+    public string ICD10Description { get; set; } = default!;
+
+    /// <summary>Primary | Secondary | Comorbidity</summary>
+    [MaxLength(20)]
+    public string DiagnosisType { get; set; } = "Primary";
+
+    /// <summary>Ordering within the encounter (1 = most important)</summary>
+    public int Rank { get; set; } = 1;
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Models/TokenBlacklist.cs
+++ b/Models/TokenBlacklist.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Sanalink.API.Models;
+
+/// <summary>Revoked JWT entries — checked by TokenRevocationMiddleware when ISO27001_TokenRevocation is on.</summary>
+public class TokenBlacklist
+{
+    public int Id { get; set; }
+
+    /// <summary>JWT ID claim (jti) of the revoked token.</summary>
+    [Required]
+    [MaxLength(100)]
+    public string Jti { get; set; } = default!;
+
+    [MaxLength(450)]
+    public string? UserId { get; set; }
+
+    public DateTime ExpiresAt { get; set; }
+    public DateTime RevokedAt { get; set; } = DateTime.UtcNow;
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,16 +1,20 @@
 using System.Text;
+using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.OpenApi.Models;
 using Sanalink.API.Data;
+using Sanalink.API.Infrastructure;
+using Sanalink.API.Middleware;
 using Sanalink.API.Models;
 using Sanalink.API.Services;
-using Sanalink.API.Middleware;
-using Microsoft.OpenApi.Models;
+using Sanalink.API.Services.Fhir;
 using Serilog;
 
-// STEP 1: Load config correctly BEFORE using it
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog((context, services, config) =>
@@ -37,7 +41,21 @@ builder.Configuration
     .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true)
     .AddEnvironmentVariables();
 
-// STEP 2: Add services
+// ── Compliance feature flags (read from config directly — IFeatureManager not available pre-Build) ──
+var flags = builder.Configuration.GetSection("FeatureManagement");
+bool httpsEnabled           = flags.GetValue<bool>(FeatureFlags.ISO27001_Https);
+bool swaggerGated           = flags.GetValue<bool>(FeatureFlags.ISO27001_SwaggerGate);
+bool rateLimitingEnabled    = flags.GetValue<bool>(FeatureFlags.ISO27001_RateLimiting);
+bool lockoutEnabled         = flags.GetValue<bool>(FeatureFlags.ISO27001_AccountLockout);
+bool tokenRevocationEnabled = flags.GetValue<bool>(FeatureFlags.ISO27001_TokenRevocation);
+bool dataRetentionEnabled   = flags.GetValue<bool>(FeatureFlags.ISO27001_DataRetention);
+bool dhis2Enabled           = flags.GetValue<bool>(FeatureFlags.DHIS2);
+bool fhirEnabled            = flags.GetValue<bool>(FeatureFlags.FHIR);
+
+// ── Feature management (IFeatureManager for runtime checks inside controllers/services) ──
+builder.Services.AddFeatureManagement();
+
+// ── Domain services ──
 builder.Services.AddScoped<IRoleSeeder, RoleSeeder>();
 builder.Services.AddScoped<INoteService, NoteService>();
 builder.Services.AddScoped<IPrescriptionService, PrescriptionService>();
@@ -47,12 +65,31 @@ builder.Services.AddScoped<IAuditLogService, AuditLogService>();
 builder.Services.AddScoped<ILabOrderService, LabOrderService>();
 builder.Services.AddScoped<IPharmacyDispenseService, PharmacyDispenseService>();
 
+// ── ISO 27001: Token Revocation (service always registered; middleware added conditionally below) ──
+builder.Services.AddScoped<ITokenRevocationService, TokenRevocationService>();
+
+// ── ISO 27001: Data Retention ──
+builder.Services.AddScoped<IDataRetentionService, DataRetentionService>();
+if (dataRetentionEnabled)
+    builder.Services.AddHostedService<DataRetentionBackgroundService>();
+
+// ── DHIS2 export ──
+builder.Services.AddHttpClient<Dhis2ExportService>();
+builder.Services.AddScoped<IDhis2ExportService, Dhis2ExportService>();
+if (dhis2Enabled)
+    builder.Services.AddHostedService<Dhis2ExportBackgroundService>();
+
+// ── FHIR mapping ──
+if (fhirEnabled)
+    builder.Services.AddScoped<FhirMappingService>();
+
+// ── CORS ──
 builder.Services.AddCors(options =>
 {
     options.AddPolicy("AllowVercel", policy =>
     {
         policy.SetIsOriginAllowed(origin =>
-            new Uri(origin).Host.EndsWith(".vercel.app"))
+                new Uri(origin).Host.EndsWith(".vercel.app"))
             .AllowAnyHeader()
             .AllowAnyMethod();
     });
@@ -65,52 +102,70 @@ builder.Services.AddCors(options =>
     });
 });
 
-// STEP 3: Use correct connection string for dev/prod
+// ── Database ──
 var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
-
-builder.Services.AddDbContext<AppDbContext>(options =>
-    options.UseNpgsql(connectionString));
-
+builder.Services.AddDbContext<AppDbContext>(options => options.UseNpgsql(connectionString));
 
 Log.Information("Current Environment: {Environment}", builder.Environment.EnvironmentName);
 Log.Information("Connection string configured for: {Database}", connectionString?.Split(';').FirstOrDefault());
 
-// STEP 4: Add Identity and Auth
+// ── Identity — lockout options driven by feature flag ──
 builder.Services.AddIdentity<ApplicationUser, IdentityRole>(options =>
 {
-    options.Password.RequireDigit = true;
-    options.Password.RequiredLength = 6;
-    options.Password.RequireNonAlphanumeric = false; // for demo
-    options.Password.RequireUppercase = false;
-    options.Password.RequireLowercase = false;
+    options.Password.RequireDigit          = true;
+    options.Password.RequiredLength        = 6;
+    options.Password.RequireNonAlphanumeric = false;
+    options.Password.RequireUppercase      = false;
+    options.Password.RequireLowercase      = false;
+
+    // ISO 27001 A.9: Account lockout
+    options.Lockout.AllowedForNewUsers        = lockoutEnabled;
+    options.Lockout.MaxFailedAccessAttempts   = lockoutEnabled ? 5 : int.MaxValue;
+    options.Lockout.DefaultLockoutTimeSpan    = TimeSpan.FromMinutes(15);
 })
 .AddEntityFrameworkStores<AppDbContext>()
 .AddDefaultTokenProviders();
 
+// ── JWT authentication ──
 builder.Services.AddAuthentication(options =>
 {
     options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
-    options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+    options.DefaultChallengeScheme    = JwtBearerDefaults.AuthenticationScheme;
 })
 .AddJwtBearer(options =>
 {
-    options.SaveToken = true;
-    options.RequireHttpsMetadata = false;
+    options.SaveToken              = true;
+    options.RequireHttpsMetadata   = false;
     options.TokenValidationParameters = new TokenValidationParameters
     {
-        ValidateIssuer = false,
-        ValidateAudience = false,
-        ValidateLifetime = true,
+        ValidateIssuer           = false,
+        ValidateAudience         = false,
+        ValidateLifetime         = true,
         ValidateIssuerSigningKey = true,
-        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(
-            builder.Configuration["Jwt:Key"]!
-        ))
+        IssuerSigningKey         = new SymmetricSecurityKey(
+            Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!))
     };
 });
 
 builder.Services.AddAuthorization();
 builder.Services.AddControllers();
 
+// ── ISO 27001 A.14: Rate Limiting ──
+// Policy is always registered; PermitLimit is set very high (≈ off) when the flag is disabled.
+builder.Services.AddRateLimiter(options =>
+{
+    options.AddSlidingWindowLimiter(FeatureFlags.RatePolicy_AuthLogin, opt =>
+    {
+        opt.PermitLimit            = rateLimitingEnabled ? 10 : 1_000_000;
+        opt.Window                 = TimeSpan.FromMinutes(1);
+        opt.SegmentsPerWindow      = 6;
+        opt.QueueProcessingOrder   = QueueProcessingOrder.OldestFirst;
+        opt.QueueLimit             = 0;
+    });
+    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
+});
+
+// ── Swagger / OpenAPI ──
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen(c =>
 {
@@ -119,10 +174,10 @@ builder.Services.AddSwaggerGen(c =>
     c.AddSecurityDefinition("Bearer", new OpenApiSecurityScheme
     {
         Description = "JWT Authorization header using the Bearer scheme. Example: \"Bearer {token}\"",
-        Name = "Authorization",
-        In = ParameterLocation.Header,
-        Type = SecuritySchemeType.Http,
-        Scheme = "bearer"
+        Name        = "Authorization",
+        In          = ParameterLocation.Header,
+        Type        = SecuritySchemeType.Http,
+        Scheme      = "bearer"
     });
 
     c.AddSecurityRequirement(new OpenApiSecurityRequirement
@@ -133,7 +188,7 @@ builder.Services.AddSwaggerGen(c =>
                 Reference = new OpenApiReference
                 {
                     Type = ReferenceType.SecurityScheme,
-                    Id = "Bearer"
+                    Id   = "Bearer"
                 }
             },
             Array.Empty<string>()
@@ -141,29 +196,45 @@ builder.Services.AddSwaggerGen(c =>
     });
 });
 
-// STEP 5: Build app and middleware
+// ── Build ──
 var app = builder.Build();
 
-app.UseSwagger();
-app.UseSwaggerUI();
+// ── ISO 27001 A.14: HTTPS enforcement ──
+if (httpsEnabled)
+{
+    app.UseHttpsRedirection();
+    if (!app.Environment.IsDevelopment())
+        app.UseHsts();
+}
+
+// ── ISO 27001 A.14: Swagger gated to development only ──
+if (!swaggerGated || app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
 
 app.UseCors(app.Environment.IsDevelopment() ? "AllowLocalhost" : "AllowVercel");
 app.UseAuthentication();
 app.UseMiddleware<AuditLoggingMiddleware>();
+
+// ── ISO 27001 A.9: Token revocation check (runs after UseAuthentication, before UseAuthorization) ──
+if (tokenRevocationEnabled)
+    app.UseMiddleware<TokenRevocationMiddleware>();
+
+app.UseRateLimiter();
 app.UseAuthorization();
 app.UseSerilogRequestLogging();
 app.MapControllers();
 
-// STEP 6: Apply migrations in production only
+// ── Startup: migrate (prod only) + seed ──
 using (var scope = app.Services.CreateScope())
 {
-    var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    var db  = scope.ServiceProvider.GetRequiredService<AppDbContext>();
     var env = scope.ServiceProvider.GetRequiredService<IWebHostEnvironment>();
 
     if (env.IsProduction())
-    {
-        db.Database.Migrate(); // applies all migrations in prod
-    }
+        db.Database.Migrate();
 
     var seeder = scope.ServiceProvider.GetRequiredService<IRoleSeeder>();
     await seeder.SeedRolesAsync();

--- a/Sanalink.API.csproj
+++ b/Sanalink.API.csproj
@@ -22,6 +22,8 @@
     <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="9.0.1" />
+    <PackageReference Include="Microsoft.FeatureManagement.AspNetCore" Version="3.5.0" />
+    <PackageReference Include="Hl7.Fhir.R4" Version="5.11.3" />
   </ItemGroup>
 
 </Project>

--- a/Services/DataRetentionBackgroundService.cs
+++ b/Services/DataRetentionBackgroundService.cs
@@ -1,0 +1,44 @@
+namespace Sanalink.API.Services;
+
+public class DataRetentionBackgroundService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IConfiguration _config;
+    private readonly ILogger<DataRetentionBackgroundService> _logger;
+
+    public DataRetentionBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        IConfiguration config,
+        ILogger<DataRetentionBackgroundService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _config = config;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            // Run at 02:00 UTC every night
+            var now = DateTime.UtcNow;
+            var nextRun = now.Date.AddDays(1).AddHours(2);
+            await Task.Delay(nextRun - now, stoppingToken);
+
+            if (stoppingToken.IsCancellationRequested) break;
+
+            try
+            {
+                var retentionDays = _config.GetValue<int>("Compliance:DataRetentionDays", 365);
+                using var scope = _scopeFactory.CreateScope();
+                var svc = scope.ServiceProvider.GetRequiredService<IDataRetentionService>();
+                await svc.PurgeOldAuditLogsAsync(retentionDays);
+                await svc.PurgeExpiredTokensAsync();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Data retention job failed");
+            }
+        }
+    }
+}

--- a/Services/DataRetentionService.cs
+++ b/Services/DataRetentionService.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Sanalink.API.Data;
+
+namespace Sanalink.API.Services;
+
+public class DataRetentionService : IDataRetentionService
+{
+    private readonly AppDbContext _db;
+    private readonly ILogger<DataRetentionService> _logger;
+
+    public DataRetentionService(AppDbContext db, ILogger<DataRetentionService> logger)
+    {
+        _db = db;
+        _logger = logger;
+    }
+
+    public async Task PurgeOldAuditLogsAsync(int retentionDays)
+    {
+        var cutoff = DateTime.UtcNow.AddDays(-retentionDays);
+        var deleted = await _db.AuditLogs
+            .Where(a => a.Timestamp < cutoff)
+            .ExecuteDeleteAsync();
+        _logger.LogInformation("Data retention: purged {Count} audit logs older than {Days} days", deleted, retentionDays);
+    }
+
+    public async Task PurgeExpiredTokensAsync()
+    {
+        var deleted = await _db.TokenBlacklists
+            .Where(t => t.ExpiresAt <= DateTime.UtcNow)
+            .ExecuteDeleteAsync();
+        _logger.LogInformation("Data retention: purged {Count} expired token blacklist entries", deleted);
+    }
+}

--- a/Services/Dhis2ExportBackgroundService.cs
+++ b/Services/Dhis2ExportBackgroundService.cs
@@ -1,0 +1,47 @@
+namespace Sanalink.API.Services;
+
+/// <summary>Pushes aggregate data to DHIS2 on the 1st of each month for the previous month.</summary>
+public class Dhis2ExportBackgroundService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<Dhis2ExportBackgroundService> _logger;
+
+    public Dhis2ExportBackgroundService(IServiceScopeFactory scopeFactory, ILogger<Dhis2ExportBackgroundService> logger)
+    {
+        _scopeFactory = scopeFactory;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var now = DateTime.UtcNow;
+            // Next run: 1st of next month at 03:00 UTC
+            var nextRun = new DateTime(now.Year, now.Month, 1, 3, 0, 0, DateTimeKind.Utc).AddMonths(1);
+            await Task.Delay(nextRun - now, stoppingToken);
+
+            if (stoppingToken.IsCancellationRequested) break;
+
+            // Export the previous calendar month
+            var previousMonth = now.AddMonths(-1);
+            var period = previousMonth.ToString("yyyyMM");
+
+            try
+            {
+                using var scope = _scopeFactory.CreateScope();
+                var svc = scope.ServiceProvider.GetRequiredService<IDhis2ExportService>();
+                var result = await svc.ExportAsync(period, stoppingToken);
+
+                if (result.Success)
+                    _logger.LogInformation("DHIS2 monthly export succeeded: {Count} values for {Period}", result.DataValuesExported, period);
+                else
+                    _logger.LogWarning("DHIS2 monthly export had issues for {Period}: {Error}", period, result.ErrorMessage);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "DHIS2 monthly export threw for period {Period}", period);
+            }
+        }
+    }
+}

--- a/Services/Dhis2ExportService.cs
+++ b/Services/Dhis2ExportService.cs
@@ -1,0 +1,118 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Sanalink.API.Data;
+
+namespace Sanalink.API.Services;
+
+public class Dhis2ExportService : IDhis2ExportService
+{
+    private readonly AppDbContext _db;
+    private readonly HttpClient _http;
+    private readonly IConfiguration _config;
+    private readonly ILogger<Dhis2ExportService> _logger;
+
+    public Dhis2ExportService(
+        AppDbContext db,
+        HttpClient http,
+        IConfiguration config,
+        ILogger<Dhis2ExportService> logger)
+    {
+        _db = db;
+        _http = http;
+        _config = config;
+        _logger = logger;
+    }
+
+    public async Task<Dhis2ExportResultDto> ExportAsync(string period, CancellationToken ct = default)
+    {
+        var baseUrl  = _config["DHIS2:BaseUrl"] ?? "";
+        var username = _config["DHIS2:Username"] ?? "";
+        var password = _config["DHIS2:Password"] ?? "";
+        var dataSet  = _config["DHIS2:DataSet"] ?? "";
+
+        if (string.IsNullOrWhiteSpace(baseUrl))
+            return new Dhis2ExportResultDto { Success = false, Period = period, ErrorMessage = "DHIS2:BaseUrl is not configured." };
+
+        // Parse period: "202601" → year=2026, month=1
+        if (period.Length != 6 || !int.TryParse(period[..4], out int year) || !int.TryParse(period[4..], out int month))
+            return new Dhis2ExportResultDto { Success = false, Period = period, ErrorMessage = "Period must be in yyyyMM format." };
+
+        var periodStart = new DateTime(year, month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var periodEnd   = periodStart.AddMonths(1);
+
+        // Build metric values
+        var newPatients      = await _db.Patients.CountAsync(p => p.CreatedAt >= periodStart && p.CreatedAt < periodEnd, ct);
+        var totalAppointments= await _db.Appointments.CountAsync(a => a.CreateAt >= periodStart && a.CreateAt < periodEnd, ct);
+        var completedEncounters = await _db.Encounters.CountAsync(e => e.ClosedAt >= periodStart && e.ClosedAt < periodEnd, ct);
+        var labOrders        = await _db.LabOrders.CountAsync(l => l.OrderedAt >= periodStart && l.OrderedAt < periodEnd, ct);
+
+        var metricValues = new Dictionary<string, int>
+        {
+            ["NewPatientRegistrations"] = newPatients,
+            ["TotalAppointments"]       = totalAppointments,
+            ["CompletedEncounters"]     = completedEncounters,
+            ["LabOrders"]               = labOrders,
+        };
+
+        // Load active mappings
+        var mappings = await _db.Dhis2Mappings
+            .Where(m => m.IsActive && m.OrgUnitUid != null)
+            .ToListAsync(ct);
+
+        if (!mappings.Any())
+            return new Dhis2ExportResultDto { Success = false, Period = period, ErrorMessage = "No active DHIS2 mappings configured." };
+
+        // Group by org unit for separate dataValueSet payloads
+        var groups = mappings
+            .Where(m => metricValues.ContainsKey(m.MetricName))
+            .GroupBy(m => m.OrgUnitUid!);
+
+        int totalExported = 0;
+
+        foreach (var group in groups)
+        {
+            var payload = new
+            {
+                dataSet,
+                completeDate = periodEnd.AddDays(-1).ToString("yyyy-MM-dd"),
+                period,
+                orgUnit = group.Key,
+                dataValues = group.Select(m => new
+                {
+                    dataElement = m.DataElementUid,
+                    value       = metricValues[m.MetricName].ToString()
+                }).ToList()
+            };
+
+            var json    = JsonSerializer.Serialize(payload);
+            var content = new StringContent(json, Encoding.UTF8, "application/json");
+
+            var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{username}:{password}"));
+            _http.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
+
+            var response = await _http.PostAsync($"{baseUrl.TrimEnd('/')}/api/dataValueSets", content, ct);
+
+            if (response.IsSuccessStatusCode)
+            {
+                totalExported += group.Count();
+                _logger.LogInformation("DHIS2 export: pushed {Count} values to org unit {OrgUnit} for period {Period}",
+                    group.Count(), group.Key, period);
+            }
+            else
+            {
+                var error = await response.Content.ReadAsStringAsync(ct);
+                _logger.LogError("DHIS2 export failed for org unit {OrgUnit}: {Status} — {Error}",
+                    group.Key, response.StatusCode, error);
+            }
+        }
+
+        return new Dhis2ExportResultDto
+        {
+            Success = totalExported > 0,
+            Period = period,
+            DataValuesExported = totalExported
+        };
+    }
+}

--- a/Services/EncounterService.cs
+++ b/Services/EncounterService.cs
@@ -1,6 +1,8 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.FeatureManagement;
 using Sanalink.API.Data;
 using Sanalink.API.DTOs;
+using Sanalink.API.Infrastructure;
 using Sanalink.API.Models;
 
 namespace Sanalink.API.Services
@@ -8,127 +10,175 @@ namespace Sanalink.API.Services
     public class EncounterService : IEncounterService
     {
         private readonly AppDbContext _context;
+        private readonly IFeatureManager _features;
 
-        public EncounterService(AppDbContext context)
+        public EncounterService(AppDbContext context, IFeatureManager features)
         {
             _context = context;
+            _features = features;
         }
 
         public async Task<IEnumerable<EncounterReadDto>> GetAllEncountersAsync(string? status = null)
         {
+            var icd10 = await _features.IsEnabledAsync(FeatureFlags.ICD10);
+
             var query = _context.Encounters
                 .Include(e => e.Patient)
                 .Include(e => e.Doctor)
                 .Include(e => e.Nurse)
                 .AsQueryable();
 
+            if (icd10)
+                query = query.Include(e => e.Diagnoses);
+
             if (!string.IsNullOrEmpty(status))
                 query = query.Where(e => e.Status == status);
 
-            return await query
-                .OrderByDescending(e => e.CreatedAt)
-                .Select(e => MapToReadDto(e))
-                .ToListAsync();
+            var encounters = await query.OrderByDescending(e => e.CreatedAt).ToListAsync();
+            return encounters.Select(e => MapToReadDto(e, icd10));
         }
 
         public async Task<EncounterReadDto?> GetEncounterByIdAsync(int id)
         {
-            var encounter = await _context.Encounters
+            var icd10 = await _features.IsEnabledAsync(FeatureFlags.ICD10);
+
+            var query = _context.Encounters
                 .Include(e => e.Patient)
                 .Include(e => e.Doctor)
                 .Include(e => e.Nurse)
-                .FirstOrDefaultAsync(e => e.Id == id);
+                .AsQueryable();
 
-            if (encounter == null) return null;
+            if (icd10)
+                query = query.Include(e => e.Diagnoses);
 
-            return MapToReadDto(encounter);
+            var encounter = await query.FirstOrDefaultAsync(e => e.Id == id);
+            return encounter is null ? null : MapToReadDto(encounter, icd10);
         }
 
         public async Task<IEnumerable<EncounterReadDto>> GetEncountersByPatientAsync(int patientId)
         {
-            return await _context.Encounters
+            var icd10 = await _features.IsEnabledAsync(FeatureFlags.ICD10);
+
+            var query = _context.Encounters
                 .Where(e => e.PatientId == patientId)
                 .Include(e => e.Patient)
                 .Include(e => e.Doctor)
                 .Include(e => e.Nurse)
-                .OrderByDescending(e => e.CreatedAt)
-                .Select(e => MapToReadDto(e))
-                .ToListAsync();
+                .AsQueryable();
+
+            if (icd10)
+                query = query.Include(e => e.Diagnoses);
+
+            var encounters = await query.OrderByDescending(e => e.CreatedAt).ToListAsync();
+            return encounters.Select(e => MapToReadDto(e, icd10));
         }
 
         public async Task<EncounterReadDto> CreateEncounterAsync(EncounterCreateDto dto, string doctorId)
         {
+            var icd10 = await _features.IsEnabledAsync(FeatureFlags.ICD10);
             var encounterNumber = await GenerateEncounterNumberAsync();
 
             var encounter = new Encounter
             {
                 EncounterNumber = encounterNumber,
-                PatientId = dto.PatientId,
-                DoctorId = doctorId,
-                Status = "Open",
-                ChiefComplaint = dto.ChiefComplaint,
-                Vitals = dto.Vitals,
-                CreatedAt = DateTime.UtcNow
+                PatientId       = dto.PatientId,
+                DoctorId        = doctorId,
+                Status          = "Open",
+                ChiefComplaint  = dto.ChiefComplaint,
+                Vitals          = dto.Vitals,
+                CreatedAt       = DateTime.UtcNow
             };
 
             _context.Encounters.Add(encounter);
             await _context.SaveChangesAsync();
 
-            // Reload with navigation properties
+            if (icd10 && dto.Diagnoses?.Any() == true)
+            {
+                var diagnoses = dto.Diagnoses.Select(d => new EncounterDiagnosis
+                {
+                    EncounterId      = encounter.Id,
+                    ICD10Code        = d.ICD10Code,
+                    ICD10Description = d.ICD10Description,
+                    DiagnosisType    = d.DiagnosisType,
+                    Rank             = d.Rank
+                });
+                _context.EncounterDiagnoses.AddRange(diagnoses);
+                await _context.SaveChangesAsync();
+            }
+
             var created = await _context.Encounters
                 .Include(e => e.Patient)
                 .Include(e => e.Doctor)
                 .Include(e => e.Nurse)
+                .Include(e => e.Diagnoses)
                 .FirstAsync(e => e.Id == encounter.Id);
 
-            return MapToReadDto(created);
+            return MapToReadDto(created, icd10);
         }
 
         public async Task<EncounterReadDto?> UpdateEncounterAsync(int id, EncounterUpdateDto dto)
         {
+            var icd10 = await _features.IsEnabledAsync(FeatureFlags.ICD10);
+
             var encounter = await _context.Encounters
                 .Include(e => e.Patient)
                 .Include(e => e.Doctor)
                 .Include(e => e.Nurse)
+                .Include(e => e.Diagnoses)
                 .FirstOrDefaultAsync(e => e.Id == id);
 
-            if (encounter == null) return null;
+            if (encounter is null) return null;
 
             if (dto.ChiefComplaint != null) encounter.ChiefComplaint = dto.ChiefComplaint;
-            if (dto.Vitals != null) encounter.Vitals = dto.Vitals;
-            if (dto.Diagnosis != null) encounter.Diagnosis = dto.Diagnosis;
-            if (dto.ClinicalNotes != null) encounter.ClinicalNotes = dto.ClinicalNotes;
-            if (dto.NurseId != null) encounter.NurseId = dto.NurseId;
+            if (dto.Vitals        != null) encounter.Vitals          = dto.Vitals;
+            if (dto.Diagnosis     != null) encounter.Diagnosis        = dto.Diagnosis;
+            if (dto.ClinicalNotes != null) encounter.ClinicalNotes    = dto.ClinicalNotes;
+            if (dto.NurseId       != null) encounter.NurseId          = dto.NurseId;
 
             encounter.UpdatedAt = DateTime.UtcNow;
 
-            await _context.SaveChangesAsync();
-
-            // Reload nurse if changed
-            if (dto.NurseId != null)
+            // ICD-10: replace all diagnoses when list is provided
+            if (icd10 && dto.Diagnoses != null)
             {
-                await _context.Entry(encounter).Reference(e => e.Nurse).LoadAsync();
+                if (encounter.Diagnoses?.Any() == true)
+                    _context.EncounterDiagnoses.RemoveRange(encounter.Diagnoses);
+
+                _context.EncounterDiagnoses.AddRange(dto.Diagnoses.Select(d => new EncounterDiagnosis
+                {
+                    EncounterId      = encounter.Id,
+                    ICD10Code        = d.ICD10Code,
+                    ICD10Description = d.ICD10Description,
+                    DiagnosisType    = d.DiagnosisType,
+                    Rank             = d.Rank
+                }));
             }
 
-            return MapToReadDto(encounter);
+            await _context.SaveChangesAsync();
+
+            if (dto.NurseId != null)
+                await _context.Entry(encounter).Reference(e => e.Nurse).LoadAsync();
+
+            if (icd10)
+                await _context.Entry(encounter).Collection(e => e.Diagnoses!).LoadAsync();
+
+            return MapToReadDto(encounter, icd10);
         }
 
         public async Task<bool> UpdateStatusAsync(int id, string newStatus)
         {
             var encounter = await _context.Encounters.FindAsync(id);
-            if (encounter == null) return false;
+            if (encounter is null) return false;
 
-            // Validate status transition: Open -> InProgress -> Closed
             var validTransitions = new Dictionary<string, string>
             {
-                { "Open", "InProgress" },
-                { "InProgress", "Closed" }
+                { "Open",       "InProgress" },
+                { "InProgress", "Closed"     }
             };
 
             if (!validTransitions.TryGetValue(encounter.Status, out var expectedNext) || expectedNext != newStatus)
                 return false;
 
-            encounter.Status = newStatus;
+            encounter.Status    = newStatus;
             encounter.UpdatedAt = DateTime.UtcNow;
 
             if (newStatus == "Closed")
@@ -140,7 +190,7 @@ namespace Sanalink.API.Services
 
         private async Task<string> GenerateEncounterNumberAsync()
         {
-            var today = DateTime.UtcNow.ToString("yyyyMMdd");
+            var today  = DateTime.UtcNow.ToString("yyyyMMdd");
             var prefix = $"ENC-{today}-";
 
             var lastEncounter = await _context.Encounters
@@ -151,7 +201,7 @@ namespace Sanalink.API.Services
             int nextNumber = 1;
             if (lastEncounter != null)
             {
-                var lastNumberStr = lastEncounter.EncounterNumber.Substring(prefix.Length);
+                var lastNumberStr = lastEncounter.EncounterNumber[prefix.Length..];
                 if (int.TryParse(lastNumberStr, out int lastNumber))
                     nextNumber = lastNumber + 1;
             }
@@ -159,25 +209,41 @@ namespace Sanalink.API.Services
             return $"{prefix}{nextNumber:D3}";
         }
 
-        private static EncounterReadDto MapToReadDto(Encounter e)
+        private static EncounterReadDto MapToReadDto(Encounter e, bool includeDiagnoses)
         {
-            return new EncounterReadDto
+            var dto = new EncounterReadDto
             {
-                Id = e.Id,
+                Id              = e.Id,
                 EncounterNumber = e.EncounterNumber,
-                PatientId = e.PatientId,
-                PatientName = e.Patient.FirstName + " " + e.Patient.LastName,
-                DoctorName = e.Doctor.FullName ?? e.Doctor.UserName!,
-                NurseName = e.Nurse?.FullName ?? e.Nurse?.UserName,
-                Status = e.Status,
-                ChiefComplaint = e.ChiefComplaint,
-                Vitals = e.Vitals,
-                Diagnosis = e.Diagnosis,
-                ClinicalNotes = e.ClinicalNotes,
-                CreatedAt = e.CreatedAt,
-                UpdatedAt = e.UpdatedAt,
-                ClosedAt = e.ClosedAt
+                PatientId       = e.PatientId,
+                PatientName     = e.Patient.FirstName + " " + e.Patient.LastName,
+                DoctorName      = e.Doctor.FullName ?? e.Doctor.UserName!,
+                NurseName       = e.Nurse?.FullName ?? e.Nurse?.UserName,
+                Status          = e.Status,
+                ChiefComplaint  = e.ChiefComplaint,
+                Vitals          = e.Vitals,
+                Diagnosis       = e.Diagnosis,
+                ClinicalNotes   = e.ClinicalNotes,
+                CreatedAt       = e.CreatedAt,
+                UpdatedAt       = e.UpdatedAt,
+                ClosedAt        = e.ClosedAt
             };
+
+            if (includeDiagnoses && e.Diagnoses?.Any() == true)
+            {
+                dto.Diagnoses = e.Diagnoses
+                    .OrderBy(d => d.Rank)
+                    .Select(d => new EncounterDiagnosisReadDto
+                    {
+                        Id               = d.Id,
+                        ICD10Code        = d.ICD10Code,
+                        ICD10Description = d.ICD10Description,
+                        DiagnosisType    = d.DiagnosisType,
+                        Rank             = d.Rank
+                    }).ToList();
+            }
+
+            return dto;
         }
     }
 }

--- a/Services/Fhir/FhirMappingService.cs
+++ b/Services/Fhir/FhirMappingService.cs
@@ -1,0 +1,129 @@
+using Hl7.Fhir.Model;
+using Sanalink.API.Models;
+using FhirPatient   = Hl7.Fhir.Model.Patient;
+using FhirEncounter = Hl7.Fhir.Model.Encounter;
+using SanalinkPatient   = Sanalink.API.Models.Patient;
+using SanalinkEncounter = Sanalink.API.Models.Encounter;
+
+namespace Sanalink.API.Services.Fhir;
+
+/// <summary>Converts internal domain models to FHIR R4 resources.</summary>
+public class FhirMappingService
+{
+    private const string PatientSystem   = "http://sanalink.io/patient-id";
+    private const string EncounterSystem = "http://sanalink.io/encounter-number";
+
+    public FhirPatient ToFhirPatient(SanalinkPatient p)
+    {
+        var resource = new FhirPatient
+        {
+            Id = p.Id.ToString(),
+            Identifier = new List<Identifier>
+            {
+                new Identifier { System = PatientSystem, Value = p.Id.ToString() }
+            },
+            Name = new List<HumanName>
+            {
+                new HumanName
+                {
+                    Use    = HumanName.NameUse.Official,
+                    Family = p.LastName,
+                    Given  = new[] { p.FirstName, p.MiddleName }
+                        .Where(n => !string.IsNullOrWhiteSpace(n))
+                        .Select(n => n!)
+                }
+            },
+            Gender = MapGender(p.Gender),
+            BirthDate = p.DateOfBirth.ToString("yyyy-MM-dd")
+        };
+
+        if (!string.IsNullOrWhiteSpace(p.Phone))
+            resource.Telecom.Add(new ContactPoint
+            {
+                System = ContactPoint.ContactPointSystem.Phone,
+                Value  = p.Phone,
+                Use    = ContactPoint.ContactPointUse.Mobile
+            });
+
+        if (!string.IsNullOrWhiteSpace(p.Email))
+            resource.Telecom.Add(new ContactPoint
+            {
+                System = ContactPoint.ContactPointSystem.Email,
+                Value  = p.Email
+            });
+
+        return resource;
+    }
+
+    public FhirEncounter ToFhirEncounter(SanalinkEncounter e)
+    {
+        var resource = new FhirEncounter
+        {
+            Id = e.Id.ToString(),
+            Identifier = new List<Identifier>
+            {
+                new Identifier { System = EncounterSystem, Value = e.EncounterNumber }
+            },
+            Status = MapEncounterStatus(e.Status),
+            Class  = new Coding("http://terminology.hl7.org/CodeSystem/v3-ActCode", "AMB", "ambulatory"),
+            Subject = new ResourceReference($"Patient/{e.PatientId}"),
+            Period  = new Period
+            {
+                StartElement = new FhirDateTime(e.CreatedAt),
+                EndElement   = e.ClosedAt.HasValue ? new FhirDateTime(e.ClosedAt.Value) : null
+            }
+        };
+
+        // Doctor participant
+        if (e.Doctor != null)
+            resource.Participant.Add(new FhirEncounter.ParticipantComponent
+            {
+                Individual = new ResourceReference($"Practitioner/{e.DoctorId}")
+            });
+
+        // ICD-10 diagnoses (populated by EncounterService when ICD10 flag is on)
+        if (e.Diagnoses != null)
+        {
+            foreach (var d in e.Diagnoses.OrderBy(x => x.Rank))
+            {
+                resource.Diagnosis.Add(new FhirEncounter.DiagnosisComponent
+                {
+                    Condition = new ResourceReference(),
+                    Use = new CodeableConcept(
+                        "http://terminology.hl7.org/CodeSystem/diagnosis-role",
+                        d.DiagnosisType == "Primary" ? "AD" : "CM",
+                        d.DiagnosisType),
+                    Rank = d.Rank
+                });
+                resource.ReasonCode.Add(new CodeableConcept(
+                    "http://hl7.org/fhir/sid/icd-10",
+                    d.ICD10Code,
+                    d.ICD10Description));
+            }
+        }
+        else if (!string.IsNullOrWhiteSpace(e.Diagnosis))
+        {
+            // Fallback: free-text diagnosis when ICD10 flag is off
+            resource.ReasonCode.Add(new CodeableConcept { Text = e.Diagnosis });
+        }
+
+        return resource;
+    }
+
+    private static AdministrativeGender MapGender(string gender) =>
+        gender.ToLower() switch
+        {
+            "male"   or "homme" or "m" => AdministrativeGender.Male,
+            "female" or "femme"  or "f" => AdministrativeGender.Female,
+            _ => AdministrativeGender.Unknown
+        };
+
+    private static FhirEncounter.EncounterStatus MapEncounterStatus(string status) =>
+        status switch
+        {
+            "Open"       => FhirEncounter.EncounterStatus.Planned,
+            "InProgress" => FhirEncounter.EncounterStatus.InProgress,
+            "Closed"     => FhirEncounter.EncounterStatus.Finished,
+            _            => FhirEncounter.EncounterStatus.Unknown
+        };
+}

--- a/Services/IDataRetentionService.cs
+++ b/Services/IDataRetentionService.cs
@@ -1,0 +1,7 @@
+namespace Sanalink.API.Services;
+
+public interface IDataRetentionService
+{
+    Task PurgeOldAuditLogsAsync(int retentionDays);
+    Task PurgeExpiredTokensAsync();
+}

--- a/Services/IDhis2ExportService.cs
+++ b/Services/IDhis2ExportService.cs
@@ -1,0 +1,14 @@
+namespace Sanalink.API.Services;
+
+public class Dhis2ExportResultDto
+{
+    public bool Success { get; set; }
+    public string Period { get; set; } = default!;
+    public int DataValuesExported { get; set; }
+    public string? ErrorMessage { get; set; }
+}
+
+public interface IDhis2ExportService
+{
+    Task<Dhis2ExportResultDto> ExportAsync(string period, CancellationToken ct = default);
+}

--- a/Services/ITokenRevocationService.cs
+++ b/Services/ITokenRevocationService.cs
@@ -1,0 +1,8 @@
+namespace Sanalink.API.Services;
+
+public interface ITokenRevocationService
+{
+    Task RevokeAsync(string jti, string userId, DateTime expiresAt);
+    Task<bool> IsRevokedAsync(string jti);
+    Task PurgeExpiredAsync();
+}

--- a/Services/TokenRevocationService.cs
+++ b/Services/TokenRevocationService.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Sanalink.API.Data;
+using Sanalink.API.Models;
+
+namespace Sanalink.API.Services;
+
+public class TokenRevocationService : ITokenRevocationService
+{
+    private readonly AppDbContext _db;
+
+    public TokenRevocationService(AppDbContext db) => _db = db;
+
+    public async Task RevokeAsync(string jti, string userId, DateTime expiresAt)
+    {
+        _db.TokenBlacklists.Add(new TokenBlacklist
+        {
+            Jti       = jti,
+            UserId    = userId,
+            ExpiresAt = expiresAt,
+            RevokedAt = DateTime.UtcNow
+        });
+        await _db.SaveChangesAsync();
+    }
+
+    public Task<bool> IsRevokedAsync(string jti)
+        => _db.TokenBlacklists.AnyAsync(t => t.Jti == jti && t.ExpiresAt > DateTime.UtcNow);
+
+    public async Task PurgeExpiredAsync()
+    {
+        await _db.TokenBlacklists
+            .Where(t => t.ExpiresAt <= DateTime.UtcNow)
+            .ExecuteDeleteAsync();
+    }
+}

--- a/appsettings.json
+++ b/appsettings.json
@@ -31,5 +31,28 @@
 
   "BetterStack": {
     "SourceToken": ""
+  },
+
+  "FeatureManagement": {
+    "ISO27001_Https":           false,
+    "ISO27001_SwaggerGate":     false,
+    "ISO27001_RateLimiting":    false,
+    "ISO27001_AccountLockout":  false,
+    "ISO27001_TokenRevocation": false,
+    "ISO27001_DataRetention":   false,
+    "ICD10":                    false,
+    "FHIR":                     false,
+    "DHIS2":                    false
+  },
+
+  "Compliance": {
+    "DataRetentionDays": 365
+  },
+
+  "DHIS2": {
+    "BaseUrl":  "",
+    "Username": "",
+    "Password": "",
+    "DataSet":  ""
   }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,402 @@
+# Sanalink API — Architecture Document
+
+## Overview
+
+Sanalink is a RESTful Electronic Health Record (EHR) backend built with **ASP.NET Core 9**. It manages the full clinical workflow of a healthcare facility — patient registration, appointments, clinical encounters, prescriptions, lab orders, pharmacy dispensing, and audit logging — secured with JWT-based authentication and role-based access control.
+
+The system is designed for deployment in **French-speaking African healthcare contexts** (terminology, gender codes, and analytics terminology reflect this), with an architecture that aligns with international health informatics standards: **FHIR R4 (HL7)**, **ICD-10 / CIM-10**, **ISO/IEC 27001**, and **DHIS2**.
+
+---
+
+## Technology Stack
+
+| Layer | Technology |
+|---|---|
+| Framework | ASP.NET Core 9 Web API |
+| ORM / Database | Entity Framework Core 9 + PostgreSQL (Npgsql) |
+| Identity | ASP.NET Core Identity |
+| Authentication | JWT Bearer — 4-hour expiry, HMAC-SHA256 signing |
+| API Documentation | Swagger / OpenAPI (Swashbuckle) |
+| Logging | Serilog — console, rolling file, optional BetterStack sink |
+| Feature Flags | Microsoft.FeatureManagement.AspNetCore |
+| FHIR R4 | Firely SDK (`Hl7.Fhir.R4`) |
+
+---
+
+## Project Structure
+
+Single-project solution — all code lives in the root of `Sanalink.API.csproj`. There is no separate test project or layered solution file.
+
+```
+Sanalink.API/
+├── Controllers/          # HTTP layer — thin, delegates to Services
+│   └── Fhir/             # FHIR R4 endpoints (gated by FHIR feature flag)
+├── Data/                 # AppDbContext (IdentityDbContext<ApplicationUser>)
+├── Dtos/                 # Input and output data transfer objects
+├── Infrastructure/       # Cross-cutting concerns (FeatureFlags constants)
+├── Middleware/           # AuditLoggingMiddleware, TokenRevocationMiddleware
+├── Migrations/           # EF Core migration history
+├── Models/               # Domain entities
+├── Services/             # Business logic interfaces + implementations
+│   └── Fhir/             # FhirMappingService (internal → FHIR R4 resources)
+├── appsettings.json      # Base configuration (all feature flags default false)
+├── appsettings.Development.json
+├── appsettings.Production.json
+└── Program.cs            # Startup — DI, middleware pipeline, feature-flag wiring
+```
+
+---
+
+## Request Pipeline
+
+```
+HTTP Request
+  │
+  ├─ [Middleware] CORS
+  ├─ [Middleware] UseAuthentication         — JWT token validated, claims populated
+  ├─ [Middleware] AuditLoggingMiddleware    — buffers req/res, writes AuditLog row after every request
+  ├─ [Middleware] TokenRevocationMiddleware — (ISO27001_TokenRevocation flag) rejects revoked JWTs
+  ├─ [Middleware] UseRateLimiter            — sliding-window policy on /auth/login
+  ├─ [Middleware] UseAuthorization          — role/policy checks
+  │
+  └─ Controller → Service → AppDbContext → PostgreSQL
+```
+
+Controllers are thin: they validate the HTTP contract and delegate all logic to scoped Services. The only exception is `AppointmentController` and `PatientController`, which query `AppDbContext` directly because their operations are simple aggregations with no reusable business logic.
+
+---
+
+## Domain Model
+
+```
+Facility
+  └── ApplicationUser (staff, IdentityUser)
+        └── FacilityId FK
+
+Patient
+  └── FacilityId FK
+
+Appointment
+  ├── PatientId FK
+  └── DoctorId FK → ApplicationUser
+
+Encounter                        ← central clinical record
+  ├── PatientId FK
+  ├── DoctorId  FK → ApplicationUser
+  ├── NurseId   FK → ApplicationUser (optional)
+  └── Diagnoses → EncounterDiagnosis[]  (ICD-10, enabled by ICD10 flag)
+
+Prescription
+  ├── PatientId FK
+  └── DoctorId  FK → ApplicationUser
+
+PharmacyDispense
+  ├── PrescriptionId FK
+  ├── PatientId      FK
+  └── DispensedById  FK → ApplicationUser
+
+LabOrder
+  ├── EncounterId FK
+  ├── PatientId   FK
+  └── DoctorId    FK → ApplicationUser
+
+Note
+  ├── PatientId FK
+  └── DoctorId  FK → ApplicationUser
+
+AuditLog
+  └── UserId FK → ApplicationUser (nullable)
+
+— Compliance tables (always migrated; usage controlled by feature flags) —
+EncounterDiagnosis   ICD-10 coded diagnoses per encounter
+TokenBlacklist       Revoked JWT entries (jti + expiry)
+Dhis2Mapping         Local metric → DHIS2 Data Element + Org Unit mapping
+```
+
+### Key model invariants
+
+- All `DateTime` columns are stored and read as **UTC** via a global EF value converter in `AppDbContext.OnModelCreating`.
+- `Encounter.Status` follows a strict linear state machine enforced in `EncounterService`: `Open → InProgress → Closed`. Any other transition is rejected.
+- `Encounter.EncounterNumber` is auto-generated as `ENC-{yyyyMMdd}-{seq:D3}` and has a unique index.
+- `Patient` is always scoped to a `Facility`. Staff queries are also scoped by the caller's `facilityId` JWT claim when present.
+
+---
+
+## Authentication & Authorization
+
+**JWT token structure** (claims included in every token):
+
+| Claim | Value |
+|---|---|
+| `sub` | `ApplicationUser.Id` |
+| `jti` | `Guid.NewGuid()` — required for token revocation |
+| `email` | User email |
+| `firstName` / `lastName` | Display name |
+| `role` / `ClaimTypes.Role` | Assigned Identity role |
+| `facilityId` | `ApplicationUser.FacilityId` (empty string if null) |
+
+**Roles** (seeded at startup):
+
+`Admin` · `Doctor` · `Nurse` · `Accueil` · `Caisse` · `DAF` · `LabTech` · `Pharmacist`
+
+**Default admin**: `admin@sanalink.com` / `Admin@123456` — change in production.
+
+Token expiry: **4 hours**. Tokens cannot be refreshed; the user must log in again (or immediately via `POST /api/v1/auth/logout` when the revocation flag is on).
+
+---
+
+## Feature Flag System
+
+All compliance-related features ship behind **Microsoft.FeatureManagement** flags. Every flag defaults to `false` — enabling one is a single config change with no code deployment required. To roll back, set the flag back to `false`.
+
+### Flag reference
+
+| Flag key | Default | What it enables |
+|---|---|---|
+| `ISO27001_Https` | `false` | `UseHttpsRedirection` + `UseHsts` (HSTS skipped in Development) |
+| `ISO27001_SwaggerGate` | `false` | Hides Swagger UI in non-Development environments |
+| `ISO27001_RateLimiting` | `false` | 10 req/min sliding window on `POST /api/v1/auth/login` |
+| `ISO27001_AccountLockout` | `false` | 5 failed login attempts → 15-minute lockout |
+| `ISO27001_TokenRevocation` | `false` | `TokenRevocationMiddleware` active; `POST /auth/logout` writes to `TokenBlacklists` |
+| `ISO27001_DataRetention` | `false` | Nightly background job purges audit logs older than `Compliance:DataRetentionDays` (default: 365) |
+| `ICD10` | `false` | Structured `EncounterDiagnosis` rows persisted and returned in encounter DTOs |
+| `FHIR` | `false` | `/fhir/r4/metadata`, `/fhir/r4/Patient`, `/fhir/r4/Encounter` endpoints active |
+| `DHIS2` | `false` | Monthly background export to DHIS2 + manual `POST /api/v1/dhis2/export` |
+
+### How flags are evaluated
+
+- **Startup-time decisions** (lockout options, rate-limit permit count, background service registration): read directly from `IConfiguration` in `Program.cs` before `builder.Build()`, because `IFeatureManager` is not available at that point.
+- **Runtime decisions** (inside services and controllers): injected `IFeatureManager` with `await _features.IsEnabledAsync("FlagName")`.
+- **Whole controllers** gated by flag: `[FeatureGate(FeatureFlags.FHIR)]` / `[FeatureGate(FeatureFlags.DHIS2)]` — returns HTTP 404 when the flag is off.
+
+### Enabling flags
+
+In `appsettings.json` (or via environment variable `FeatureManagement__ISO27001_Https=true`):
+
+```json
+"FeatureManagement": {
+  "ISO27001_Https":           false,
+  "ISO27001_SwaggerGate":     false,
+  "ISO27001_RateLimiting":    false,
+  "ISO27001_AccountLockout":  false,
+  "ISO27001_TokenRevocation": false,
+  "ISO27001_DataRetention":   false,
+  "ICD10":                    false,
+  "FHIR":                     false,
+  "DHIS2":                    false
+}
+```
+
+---
+
+## Compliance Alignment
+
+### FHIR R4 (HL7)
+
+**Status: Implemented behind `FHIR` flag.**
+
+The API exposes a parallel FHIR R4 façade at `/fhir/r4/` using the **Firely SDK** (`Hl7.Fhir.R4`). Responses use `Content-Type: application/fhir+json`.
+
+**Implemented endpoints:**
+
+| FHIR endpoint | Maps to |
+|---|---|
+| `GET /fhir/r4/metadata` | `CapabilityStatement` listing supported resources |
+| `GET /fhir/r4/Patient/{id}` | Single patient by internal ID |
+| `GET /fhir/r4/Patient?family=&given=` | Patient search — returns `Bundle` of type `searchset` |
+| `GET /fhir/r4/Encounter/{id}` | Single encounter with ICD-10 diagnoses as `ReasonCode` |
+| `GET /fhir/r4/Encounter?subject=Patient/{id}&status=` | Encounter search — returns `Bundle` |
+
+**Internal model → FHIR R4 resource mapping:**
+
+| Internal model | FHIR R4 resource |
+|---|---|
+| `Patient` | `Patient` — name, gender, birthDate, telecom |
+| `Encounter` | `Encounter` — status, class (AMB), subject, participant, period, reasonCode |
+| `Prescription` | `MedicationRequest` *(roadmap)* |
+| `LabOrder` | `ServiceRequest` *(roadmap)* |
+| `PharmacyDispense` | `MedicationDispense` *(roadmap)* |
+| `Appointment` | `Appointment` *(roadmap)* |
+| `Note` | `DocumentReference` *(roadmap)* |
+| `Facility` | `Organization` *(roadmap)* |
+| `ApplicationUser` | `Practitioner` *(roadmap)* |
+
+**Gender mapping** (internal string → FHIR `AdministrativeGender`):
+
+| Internal value | FHIR code |
+|---|---|
+| `male` / `homme` / `m` | `male` |
+| `female` / `femme` / `f` | `female` |
+| any other | `unknown` |
+
+**Encounter status mapping:**
+
+| Internal status | FHIR `EncounterStatus` |
+|---|---|
+| `Open` | `planned` |
+| `InProgress` | `in-progress` |
+| `Closed` | `finished` |
+
+---
+
+### ICD-10 / CIM-10
+
+**Status: Implemented behind `ICD10` flag.**
+
+When the `ICD10` flag is enabled, the `Encounter` entity supports structured, multi-coded diagnoses via the `EncounterDiagnoses` table in place of the legacy free-text `Diagnosis` field. The free-text field is preserved for backward compatibility.
+
+**`EncounterDiagnosis` schema:**
+
+| Column | Description |
+|---|---|
+| `ICD10Code` | ICD-10 / CIM-10 code, e.g. `J18.9` |
+| `ICD10Description` | Human-readable label, e.g. `Pneumonie, sans précision` |
+| `DiagnosisType` | `Primary` · `Secondary` · `Comorbidity` |
+| `Rank` | Ordering within the encounter (1 = most significant) |
+
+**API behavior:**
+- `EncounterCreateDto` and `EncounterUpdateDto` accept an optional `Diagnoses[]` list.
+- `EncounterReadDto` returns both `Diagnosis` (free-text, always present) and `Diagnoses[]` (ICD-10 list, present only when flag is on).
+- In FHIR responses, coded diagnoses appear as `Encounter.reasonCode` with system `http://hl7.org/fhir/sid/icd-10`.
+
+**Gap / roadmap:** Code validation against a full ICD-10 reference table (autocomplete, typo prevention) is not yet implemented. The API currently trusts the caller to supply valid codes.
+
+---
+
+### ISO/IEC 27001
+
+**Status: Implemented behind individual `ISO27001_*` flags.**
+
+The following controls from ISO/IEC 27001 Annex A are addressed:
+
+#### A.9 — Access Control
+
+| Control | Implementation |
+|---|---|
+| A.9.4.2 — Secure log-on | JWT Bearer authentication; `IsActive` check on every login |
+| A.9.4.3 — Password management | ASP.NET Identity enforces digit + minimum length requirements |
+| A.9.1.1 — Access control policy | Eight distinct roles with per-endpoint `[Authorize(Roles="...")]` |
+| A.9.4.5 — Access control (lockout) | `ISO27001_AccountLockout` flag — 5 attempts → 15-min lockout |
+| A.9.2.6 — Removal of access rights | `IsActive = false` immediately blocks login without deleting the account |
+| A.9.4.4 — Token revocation | `ISO27001_TokenRevocation` flag — `POST /auth/logout` blacklists the `jti` claim; `TokenRevocationMiddleware` rejects blacklisted tokens on every subsequent request |
+
+#### A.12 — Operations Security
+
+| Control | Implementation |
+|---|---|
+| A.12.4.1 — Event logging | `AuditLoggingMiddleware` captures every HTTP request: userId, role, facilityId, action, resource, resourceId, endpoint, old/new values (sensitive fields masked), status code, IP address, user agent, timestamp |
+| A.12.4.2 — Protection of log information | Auth endpoints (`/auth/login`, `/auth/register-staff`) are excluded from body capture; `SensitiveDataMasker` scrubs `password`, `token`, `key`, etc. from stored bodies |
+| A.12.4.3 — Administrator and operator logs | All write actions by any role (including Admin) are captured in `AuditLogs` |
+| A.12.1.3 — Capacity management | `ISO27001_DataRetention` flag — nightly job purges audit logs older than `Compliance:DataRetentionDays` (default 365) and expired token blacklist entries |
+
+#### A.14 — System Acquisition, Development and Maintenance
+
+| Control | Implementation |
+|---|---|
+| A.14.1.2 — Securing app services | `ISO27001_Https` flag — `UseHttpsRedirection` + `UseHsts` in production |
+| A.14.2.5 — Secure development principles | `ISO27001_SwaggerGate` flag — Swagger UI restricted to Development environment |
+| A.14.1.3 — Rate limiting | `ISO27001_RateLimiting` flag — sliding-window rate limiting on login endpoint |
+
+#### Multi-tenancy isolation (data boundary control)
+
+All patient and staff queries are scoped to the caller's `facilityId` JWT claim when present. An Admin without a facility assignment sees all records across facilities.
+
+---
+
+### DHIS2
+
+**Status: Implemented behind `DHIS2` flag.**
+
+The integration exports aggregate health metrics from Sanalink to a DHIS2 instance using the **DHIS2 Data Value Sets API** (`POST /api/dataValueSets`).
+
+**Exported metrics (current):**
+
+| Metric name | Description |
+|---|---|
+| `NewPatientRegistrations` | Patients created within the period |
+| `TotalAppointments` | Appointments booked within the period |
+| `CompletedEncounters` | Encounters closed within the period |
+| `LabOrders` | Lab orders placed within the period |
+
+**Configuration** (`appsettings.json`):
+
+```json
+"DHIS2": {
+  "BaseUrl":  "https://your-dhis2-instance.org",
+  "Username": "...",
+  "Password": "...",
+  "DataSet":  "..."
+}
+```
+
+**Mapping table (`Dhis2Mappings`):**
+
+Each row maps a `MetricName` to a DHIS2 `DataElementUid`, an optional `FacilityId`, and its corresponding DHIS2 `OrgUnitUid`. Multiple org units are handled by grouping mappings and POSTing one `dataValueSet` payload per org unit.
+
+**Trigger modes:**
+- **Automatic**: `Dhis2ExportBackgroundService` fires on the 1st of each month at 03:00 UTC, exporting the previous calendar month.
+- **Manual**: `POST /api/v1/dhis2/export?period=202601` (Admin/DAF roles only) — useful for backfills or re-exports.
+
+**Period format**: `yyyyMM` (e.g., `202601` for January 2026), matching DHIS2's monthly period convention.
+
+**Gap / roadmap:** Adding new metrics requires inserting rows into `Dhis2Mappings` and adding the corresponding aggregate query to `Dhis2ExportService.ExportAsync`. Daily and weekly period types are defined in the mapping model but not yet handled by the export logic.
+
+---
+
+## Audit Log
+
+Every HTTP request is intercepted by `AuditLoggingMiddleware` regardless of outcome. The following is stored per request:
+
+| Field | Source |
+|---|---|
+| `UserId` | JWT `sub` claim |
+| `UserEmail` | JWT `email` claim |
+| `UserRole` | JWT `role` claim |
+| `FacilityId` | JWT `facilityId` claim |
+| `Action` | `POST→CREATE`, `PUT/PATCH→UPDATE`, `DELETE→DELETE`, `GET→VIEW` |
+| `Resource` | 3rd URL segment (`/api/v1/{Resource}/...`) |
+| `ResourceId` | 4th URL segment if numeric |
+| `Endpoint` | Full request path |
+| `OldValue` | Request body (masked) for UPDATE/DELETE |
+| `NewValue` | Response body (masked) for CREATE/UPDATE |
+| `StatusCode` | HTTP response status |
+| `IpAddress` | `RemoteIpAddress` |
+| `UserAgent` | Truncated to 500 chars |
+| `Timestamp` | `DateTime.UtcNow` |
+
+Sensitive JSON keys (`password`, `passwordHash`, `token`, `accessToken`, `refreshToken`, `secret`, `key`, `jwt`, `authorization`) are replaced with `"***"` by `SensitiveDataMasker` before storage. Auth endpoints (`/auth/login`, `/auth/register-staff`) skip body capture entirely.
+
+---
+
+## Analytics Endpoints
+
+These endpoints feed dashboards and, when the DHIS2 flag is enabled, flow into DHIS2 exports.
+
+| Endpoint | Description |
+|---|---|
+| `GET /api/v1/appointment/analytics` | Totals: appointments by status, patient count, prescription count |
+| `GET /api/v1/appointment/appointments-per-day` | 10-day appointment time series |
+| `GET /api/v1/patient/registrations?days=7` | Daily patient registration counts for N days |
+| `GET /api/v1/patient/recent` | Count of patients registered in the last 7 days |
+| `GET /api/v1/patient/gender-distribution` | Male / female / other breakdown |
+| `GET /api/v1/patient/per-facility` | Patient count per facility |
+| `GET /api/v1/patient/natality?days=30` | Newborn registrations (DateOfBirth within last 30 days) |
+| `GET /api/v1/auth/active-staff-count` | Active doctor and nurse headcount |
+
+---
+
+## Deployment
+
+**Development**: Run locally with `dotnet run`. Swagger UI at `http://localhost:5189/swagger`. Apply migrations manually with `dotnet ef database update`.
+
+**Production**: Docker image built from `Dockerfile` (multi-stage, ASP.NET 9 runtime). EF migrations are applied automatically on startup via `db.Database.Migrate()`. Swagger is disabled when `ISO27001_SwaggerGate: true`. CORS allows `*.vercel.app` origins.
+
+**Environment variables** (production secrets — never commit values):
+
+| Variable | Purpose |
+|---|---|
+| `ConnectionStrings__DefaultConnection` | PostgreSQL connection string |
+| `Jwt__Key` | JWT signing key (min. 32 bytes, base64) |
+| `BetterStack__SourceToken` | BetterStack log ingestion token |
+| `DHIS2__BaseUrl` / `__Username` / `__Password` | DHIS2 push credentials |
+| `FeatureManagement__<FlagName>` | Override any feature flag per-environment |


### PR DESCRIPTION
… and DHIS2

All compliance controls ship behind Microsoft.FeatureManagement flags that default to false. Enabling any feature is a single config change with no code deployment required. Disabling reverts to the original behaviour.

ISO/IEC 27001 (A.9, A.12, A.14):
- ISO27001_Https: UseHttpsRedirection + UseHsts in production
- ISO27001_SwaggerGate: hides Swagger UI outside Development
- ISO27001_RateLimiting: 10 req/min sliding window on POST /auth/login
- ISO27001_AccountLockout: 5 failed attempts triggers 15-min lockout
- ISO27001_TokenRevocation: POST /auth/logout blacklists the JWT jti
- ISO27001_DataRetention: nightly job purges old audit logs and tokens

ICD-10 / CIM-10:
- ICD10: EncounterDiagnosis table with coded diagnoses per encounter
- DTOs extended with optional Diagnoses[] list
- FHIR Encounter.reasonCode populated from coded diagnoses

FHIR R4 (HL7) via Firely SDK:
- FHIR: /fhir/r4/metadata, /fhir/r4/Patient, /fhir/r4/Encounter
- Returns application/fhir+json; FhirMappingService translates models

DHIS2:
- DHIS2: Dhis2ExportService posts aggregate metrics to DHIS2 API
- Dhis2Mapping table configures DataElement/OrgUnit mappings
- Monthly background export + manual POST /api/v1/dhis2/export

Infrastructure:
- EF migration AddComplianceTables: EncounterDiagnoses, TokenBlacklists, Dhis2Mappings
- jti claim added to all JWT tokens for revocation support
- CLAUDE.md: codebase guidance for Claude Code
- docs/ARCHITECTURE.md: full architecture and compliance alignment document